### PR TITLE
Support cell library inclusion.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Temporary files
 tmp/**
+
+# Cell libraries
+cell_libraries/**

--- a/helpers.py
+++ b/helpers.py
@@ -1,6 +1,6 @@
 from itertools import combinations, permutations
 from mako.template import Template
-from os import system
+from os import system, listdir, path
 from json import dumps, load
 
 def is_int(s):
@@ -134,10 +134,14 @@ def generate_optimized_labeling(filename):
 		tmp = {** ordinary_labels}
 	return labels
 
-def parse_verilog(verilog_files, top_module, template_file='template/yosys.txt'):
+def parse_verilog(verilog_files, top_module, library=None, template_file='template/yosys.txt'):
 	template = Template(filename=template_file)
 	basename = ''.join(verilog_files.split('.')[:-1])
 	files = verilog_files if type(verilog_files) == list else [verilog_files]
+	if (library):
+		for lib in listdir(library):
+			if lib.endswith(".v"):
+				files.append(path.join(library, lib))
 	yosys_script = template.render(input_files=files, top_module=top_module)
 	with open('tmp/synth.ys', 'w') as filename:
 		filename.write(yosys_script)

--- a/verify.py
+++ b/verify.py
@@ -40,6 +40,9 @@ if __name__ == '__main__':
 	parser.add_argument('-p', '--parse-verilog', nargs=2,
 		metavar=('<netlist>', '<top module>'),
 		help='parse verilog file and generate labeling template')
+	parser.add_argument('-l', '--library', nargs=1,
+		metavar=('<library dir>'),
+		help='use verilog cell libraries located in library dir')
 	parser.add_argument('-o', '--optimized', action='store_true',
 		help='run verification in parallel')
 	parser.add_argument('-c', '--check', nargs=4, metavar=('<netlist>', '<order>', '<labeling>', '<mode>'),
@@ -48,7 +51,10 @@ if __name__ == '__main__':
 		help='check if a netlist <netlist> is <order>-order independent with the <labeling> as initial labeling')
 	args = vars(parser.parse_args())
 	if args['parse_verilog']:
-		parse_verilog(args['parse_verilog'][0], args['parse_verilog'][1])
+		if args['library']:
+			parse_verilog(args['parse_verilog'][0], args['parse_verilog'][1], args['library'][0])
+		else:	
+			parse_verilog(args['parse_verilog'][0], args['parse_verilog'][1])
 	if args['independence_check']:
 		shares = get_shares(args['independence_check'][2])
 		labels = generate_labeling(args['independence_check'][2])[0]


### PR DESCRIPTION
## Current problem
The current version of `rebecca` does not support the inclusion of cell libraries.
However, cell libraries are needed when parsing Verilog files which depend on external modules.

## Solution
This PR enables `rebecca` to take a cell library path as an additional command line argument. The cell library path is expected to include all cell libraries needed to parse the main Verilog file containing the top module.
Cell libraries are passed on to the dynamically generated `yosys` script as additional Verilog files.